### PR TITLE
Multi-buffering

### DIFF
--- a/Engine/Engine.cpp
+++ b/Engine/Engine.cpp
@@ -161,6 +161,10 @@ void Engine::update()
 
 	if (mp_scene->isUpdate(frame) || mp_renderer->NeedUpdate(frame))
 	{
+		mp_renderer->WaitForSwapchainImageFence();
+
+		mp_scene->Update(frame);
+
 		mp_renderer->beginRecordCommandBuffers(mp_renderer->getCommandBuffer(frame), mp_renderer->getFrameBuffer(frame));
 		mp_scene->Render(mp_renderer->getCommandBuffer(frame), frame);
 		mp_renderer->endRecordCommandBuffers(mp_renderer->getCommandBuffer(frame));

--- a/Engine/Engine.cpp
+++ b/Engine/Engine.cpp
@@ -27,18 +27,6 @@ Engine::~Engine()
 
 	mp_renderer->cleanSwapchain();
 
-	for (size_t i = 0; i < mp_scene->getObjects().size(); i++)
-	{
-		for (size_t t = 0; t < mp_scene->getObjects()[i]->getMeshesCount(); t++)
-		{
-			mp_scene->getObjects()[i]->getMesh(t).DestroyBuffers();
-			mp_scene->getObjects()[i]->getMesh(t).getMaterial()->DestroyTexture();
-		}
-
-		mp_scene->getObjects()[i]->destroy();
-	}
-
-	mp_scene->Clean();
 	mp_scene.reset();
 
 	vkDestroyDescriptorPool(mp_renderer->getDevice(), mp_renderer->getDescriptorPool(), nullptr);
@@ -168,22 +156,21 @@ void Engine::update()
 	m_last_time = current_time;
 
 	const int32_t frame = mp_renderer->AcquireNextImage();
-	if (frame != -1 && (mp_scene->isUpdate(frame) || mp_renderer->NeedUpdate(frame)))
+	if (frame == -1)
+		return;
+
+	if (mp_scene->isUpdate(frame) || mp_renderer->NeedUpdate(frame))
 	{
 		mp_renderer->beginRecordCommandBuffers(mp_renderer->getCommandBuffer(frame), mp_renderer->getFrameBuffer(frame));
-		mp_scene->render(mp_renderer->getCommandBuffer(frame), frame);
+		mp_scene->Render(mp_renderer->getCommandBuffer(frame), frame);
 		mp_renderer->endRecordCommandBuffers(mp_renderer->getCommandBuffer(frame));
 
+		mp_scene->Clean(frame);
 		mp_renderer->SetUpdated(frame);
-		
-		if (mp_renderer->IsUpdated() || mp_scene->IsUpdated())
-		{
-			mp_scene->Clean();
-		}
 	}
 
-	mp_main_camera->UpdateUBO(static_cast<float>(mp_config->width), static_cast<float>(mp_config->height));
-	mp_scene->UpdateUBO(mp_main_camera, mp_renderer);
+	mp_main_camera->UpdateUBO(static_cast<float>(mp_config->width), static_cast<float>(mp_config->height), frame);
+	mp_scene->UpdateUBO(mp_main_camera, mp_renderer, frame);
 
 	//std::this_thread::sleep_for(std::chrono::nanoseconds(500));//delete when not streaming
 }

--- a/Engine/cameras/Camera.cpp
+++ b/Engine/cameras/Camera.cpp
@@ -14,9 +14,7 @@ Camera::Camera()
 	m_rotation = { 0.0f, 0.0f, 0.0f };
 	m_delta_position = { 0.f, 0.f, 0.f };
 
-	m_ubo.model = {};
-	m_ubo.proj = {};
-	m_ubo.view = {};
+	m_ubo.fill({ {},{},{} });
 }
 
 
@@ -24,11 +22,11 @@ Camera::~Camera()
 {
 }
 
-void Camera::UpdateUBO(const float& width, const float& height)
+void Camera::UpdateUBO(const float& width, const float& height, const int32_t frame)
 {
-	m_ubo.view = updateView(m_pitch, m_yaw, m_position);
-	m_ubo.proj = createProjMatrix(width, height);
-	m_ubo.proj[1][1] *= -1;
+	m_ubo[frame].view = updateView(m_pitch, m_yaw, m_position);
+	m_ubo[frame].proj = createProjMatrix(width, height);
+	m_ubo[frame].proj[1][1] *= -1;
 }
 
 void Camera::UpdatePosition(const float& dt)
@@ -136,7 +134,7 @@ const float & Camera::getYaw()
 	return m_yaw;
 }
 
-UniformBufferObject& Camera::getUBO()
+UniformBufferObject& Camera::GetUBO(const int32_t frame)
 {
-	return m_ubo;
+	return m_ubo[frame];
 }

--- a/Engine/cameras/Camera.h
+++ b/Engine/cameras/Camera.h
@@ -14,7 +14,7 @@ public:
 	Camera();
 	~Camera();
 
-	void UpdateUBO(const float& width, const float& height);
+	void UpdateUBO(const float& width, const float& height, const int32_t frame);
 	void UpdatePosition(const float& dt);
 
 	void MoveForward(const float& speed);
@@ -36,7 +36,7 @@ public:
 	void setYaw(const float& yaw);
 	const float& getYaw();
 
-	UniformBufferObject& getUBO();
+	UniformBufferObject& GetUBO(const int32_t frame);
 
 private:
 
@@ -50,7 +50,7 @@ private:
 	float m_pitch;
 	glm::vec2 last_mouse_pos;
 
-	UniformBufferObject m_ubo;
+	std::array<UniformBufferObject, MAX_FRAMES_IN_FLIGHT> m_ubo;
 };
 
 #endif // !_CAMERA_H

--- a/Engine/graphics/Graphics.h
+++ b/Engine/graphics/Graphics.h
@@ -4,6 +4,7 @@
 #include "vulkan\vulkan.h"
 #include <vector>
 
+constexpr unsigned int MAX_FRAMES_IN_FLIGHT = 3;
 
 struct Extensions
 {

--- a/Engine/renderer/Renderer.cpp
+++ b/Engine/renderer/Renderer.cpp
@@ -136,6 +136,11 @@ int32_t Renderer::AcquireNextImage()
 	return m_current_image;
 }
 
+void Renderer::WaitForSwapchainImageFence()
+{
+	vkWaitForFences(m_graphic.device, 1, &m_graphic.fences_in_flight[m_current_image], VK_TRUE, std::numeric_limits<uint64_t>::max());
+}
+
 void Renderer::setupInstance(GLFWwindow& window)
 {
 	m_instance = std::make_unique<VulkanInstance>(m_graphic);
@@ -329,8 +334,6 @@ void Renderer::allocateCommandBuffers()
 
 void Renderer::beginRecordCommandBuffers(VkCommandBuffer & commandBuffer, VkFramebuffer& frameBuffer)
 {
-	vkWaitForFences(m_graphic.device, 1, &m_graphic.fences_in_flight[m_current_image], VK_TRUE, std::numeric_limits<uint64_t>::max());
-
 	// reset command buffer
 	if (vkResetCommandBuffer(commandBuffer, VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT) != VK_SUCCESS)
 	{

--- a/Engine/renderer/Renderer.h
+++ b/Engine/renderer/Renderer.h
@@ -36,6 +36,7 @@ public:
 
 	int32_t draw();
 	int32_t AcquireNextImage();
+	void WaitForSwapchainImageFence();
 
 	void setupInstance(GLFWwindow& window);
 	void setupDevice();

--- a/Engine/renderer/Renderer.h
+++ b/Engine/renderer/Renderer.h
@@ -28,8 +28,6 @@
 
 #include "../Logger.h"
 
-constexpr unsigned int MAX_FRAMES_IN_FLIGHT = 3;
-
 class Renderer
 {
 public:

--- a/Engine/world/GameObject.cpp
+++ b/Engine/world/GameObject.cpp
@@ -63,17 +63,17 @@ void GameObject::bindMatToMesh(const size_t& index, std::shared_ptr<Material> p_
 void GameObject::LoadMesh(std::vector<Vertex>& vertices, const std::vector<uint32_t>& indices)
 {
 	Mesh mesh(vertices, indices, mp_renderer);
-	mesh.CreateBuffers(mp_renderer);
-
 	m_meshes.push_back(std::move(mesh));
+
+	m_meshes[m_meshes.size() - 1].CreateBuffers(mp_renderer);
 }
 
 void GameObject::loadMesh(const std::string& mesh_path)
 {
 	Mesh mesh(mesh_path, mp_renderer);
-	mesh.CreateBuffers(mp_renderer);
-
 	m_meshes.push_back(std::move(mesh));
+
+	m_meshes[m_meshes.size() - 1].CreateBuffers(mp_renderer);
 }
 
 void GameObject::UpdateMesh(const size_t& index, const std::vector<Vertex>& vertices, const std::vector<uint32_t>& indices)

--- a/Engine/world/GameObject.cpp
+++ b/Engine/world/GameObject.cpp
@@ -33,8 +33,8 @@ void GameObject::Destroy(const int32_t frame)
 {
 	for (size_t i = 0; i < m_meshes.size(); i++)
 	{
-		m_meshes[i].DestroyBuffers(frame);
-		if (m_meshes[i].IsCleaned())
+		m_meshes[i]->DestroyBuffers(frame);
+		if (m_meshes[i]->IsCleaned())
 		{
 			m_meshes.erase(m_meshes.begin() + i);
 		}
@@ -48,7 +48,7 @@ void GameObject::registerDrawCmd(VkCommandBuffer& command_buffer, const int32_t 
 {
 	for (size_t i = 0; i < m_meshes.size(); i++)
 	{
-		m_meshes[i].draw(command_buffer, frame);
+		m_meshes[i]->draw(command_buffer, frame);
 	}
 }
 
@@ -56,52 +56,48 @@ void GameObject::bindMatToMesh(const size_t& index, std::shared_ptr<Material> p_
 {
 	for (size_t i = 0; i < m_ubo.size(); i++)
 	{
-		m_meshes[index].bindMaterial(p_material, m_ubo[i], mp_renderer);
+		m_meshes[index]->bindMaterial(p_material, m_ubo[i], mp_renderer);
 	}
 }
 
-void GameObject::LoadMesh(std::vector<Vertex>& vertices, const std::vector<uint32_t>& indices)
+void GameObject::LoadMesh(std::vector<Vertex> vertices, std::vector<uint32_t> indices)
 {
-	Mesh mesh(vertices, indices, mp_renderer);
-	m_meshes.push_back(std::move(mesh));
-
-	m_meshes[m_meshes.size() - 1].CreateBuffers(mp_renderer);
+	m_meshes.push_back(std::make_unique<Mesh>(m_meshes.size(), vertices, indices, mp_renderer));
+	m_meshes[m_meshes.size() - 1]->CreateBuffers(mp_renderer);
 }
 
 void GameObject::loadMesh(const std::string& mesh_path)
 {
-	Mesh mesh(mesh_path, mp_renderer);
-	m_meshes.push_back(std::move(mesh));
-
-	m_meshes[m_meshes.size() - 1].CreateBuffers(mp_renderer);
+	m_meshes.push_back(std::make_unique<Mesh>(m_meshes.size(), mesh_path, mp_renderer));
+	m_meshes[m_meshes.size() - 1]->CreateBuffers(mp_renderer);
 }
 
 void GameObject::UpdateMesh(const size_t& index, const std::vector<Vertex>& vertices, const std::vector<uint32_t>& indices)
 {
-	m_meshes[index].SetVertices(vertices);
-	m_meshes[index].SetIndices(indices);
-	m_meshes[index].CreateBuffers(mp_renderer);
+	m_meshes[index]->SetVertices(vertices);
+	m_meshes[index]->SetIndices(indices);
+	m_meshes[index]->CreateBuffers(mp_renderer);
 }
 
 std::vector<Vertex> GameObject::GetVertices(const size_t& index)
 {
-	return m_meshes[index].get_vertices();
+	return m_meshes[index]->get_vertices();
 }
 
 std::vector<uint32_t> GameObject::GetIndices(const size_t& index)
 {
-	return m_meshes[index].get_indices();
+	return m_meshes[index]->get_indices();
 }
 
-Mesh& GameObject::getMesh(const size_t& index)
+const std::unique_ptr<Mesh>& GameObject::getMesh(const size_t& index)
 {
 	return m_meshes[index];
 }
 
 void GameObject::setMesh(const size_t& index, std::vector<Vertex> vertices)
 {
-	m_meshes[index].SetVertices(vertices);
-	m_meshes[index].CreateBuffers(mp_renderer);
+	m_meshes[index]->SetVertices(vertices);
+	m_meshes[index]->CreateBuffers(mp_renderer);
 }
 
 void GameObject::setPosition(const glm::vec3& pos)

--- a/Engine/world/GameObject.h
+++ b/Engine/world/GameObject.h
@@ -19,7 +19,7 @@ public:
 	void bindMatToMesh(const size_t& index, std::shared_ptr<Material> p_material);
 
 	// MESH
-	void LoadMesh(std::vector<Vertex>& vertices, const std::vector<uint32_t>& indices);
+	void LoadMesh(std::vector<Vertex> vertices, std::vector<uint32_t> indices);
 	void loadMesh(const std::string& mesh_path);
 	
 	void UpdateMesh(const size_t& index, const std::vector<Vertex>& vertices, const std::vector<uint32_t>& indices);
@@ -27,7 +27,7 @@ public:
 	std::vector<Vertex> GetVertices(const size_t& index);
 	std::vector<uint32_t> GetIndices(const size_t& index);
 
-	Mesh& getMesh(const size_t& index);
+	const std::unique_ptr<Mesh>& getMesh(const size_t& index);
 	void setMesh(const size_t& index, std::vector<Vertex> vertices);
 
 	void setPosition(const glm::vec3& pos);
@@ -43,7 +43,7 @@ public:
 	const bool Deleted();
 	
 private:
-	std::vector<Mesh> m_meshes;
+	std::vector<std::unique_ptr<Mesh>> m_meshes;
 
 	std::array<VkBuffer, MAX_FRAMES_IN_FLIGHT> m_ubo;
 	std::array<VkDeviceMemory, MAX_FRAMES_IN_FLIGHT> m_ubo_memory;

--- a/Engine/world/GameObject.h
+++ b/Engine/world/GameObject.h
@@ -13,10 +13,9 @@ public:
 	GameObject(std::shared_ptr<Renderer> p_renderer);
 	~GameObject();
 
-	void destroy();
+	void Destroy(const int32_t frame);
 
-	void registerDrawCmd(VkCommandBuffer& command_buffer);
-	void Clean();
+	void registerDrawCmd(VkCommandBuffer& command_buffer, const int32_t frame);
 	void bindMatToMesh(const size_t& index, std::shared_ptr<Material> p_material);
 
 	// MESH
@@ -37,16 +36,17 @@ public:
 	void setRotation(const glm::vec3& rot);
 	const glm::vec3& getRotation();
 
-	VkBuffer& getUBO();
-	VkDeviceMemory& getUBOMemory();
+	VkBuffer& GetUBO(const int32_t frame);
+	VkDeviceMemory& GetUBOMemory(const int32_t frame);
 
 	const size_t& getMeshesCount();
+	const bool Deleted();
 	
 private:
 	std::vector<Mesh> m_meshes;
 
-	VkBuffer m_ubo;
-	VkDeviceMemory m_ubo_memory;
+	std::array<VkBuffer, MAX_FRAMES_IN_FLIGHT> m_ubo;
+	std::array<VkDeviceMemory, MAX_FRAMES_IN_FLIGHT> m_ubo_memory;
 
 	glm::vec3 m_position;
 	glm::vec3 m_rotation;

--- a/Engine/world/GameObject.h
+++ b/Engine/world/GameObject.h
@@ -13,6 +13,7 @@ public:
 	GameObject(std::shared_ptr<Renderer> p_renderer);
 	~GameObject();
 
+	void Update(const int32_t frame);
 	void Destroy(const int32_t frame);
 
 	void registerDrawCmd(VkCommandBuffer& command_buffer, const int32_t frame);
@@ -43,6 +44,7 @@ public:
 	const bool Deleted();
 	
 private:
+	std::vector<int32_t> m_mesh_to_update;
 	std::vector<std::unique_ptr<Mesh>> m_meshes;
 
 	std::array<VkBuffer, MAX_FRAMES_IN_FLIGHT> m_ubo;

--- a/Engine/world/Material.cpp
+++ b/Engine/world/Material.cpp
@@ -12,7 +12,6 @@ Material::Material(const TSHADER shader, std::shared_ptr<Renderer> p_renderer) :
 Material::~Material()
 {
 	m_texture.reset();
-
 }
 
 void Material::setColor(glm::vec3 color)

--- a/Engine/world/Mesh.cpp
+++ b/Engine/world/Mesh.cpp
@@ -1,13 +1,13 @@
 #include "Mesh.h"
 
-Mesh::Mesh(std::vector<Vertex> vertices, const std::vector<uint32_t>& indices, std::shared_ptr<Renderer> p_renderer) : m_vertices(vertices), m_indices(indices), mp_renderer(p_renderer)
+Mesh::Mesh(const int ID, std::vector<Vertex> vertices, std::vector<uint32_t> indices, std::shared_ptr<Renderer> p_renderer) : m_ID(ID), m_vertices(vertices), m_indices(indices), mp_renderer(p_renderer)
 {
 	m_buffer.fill({VK_NULL_HANDLE});
 	m_old_buffer.fill({ VK_NULL_HANDLE });
 	m_destroyed = false;
 }
 
-Mesh::Mesh(const std::string& obj_path, std::shared_ptr<Renderer> p_renderer) : m_obj_path(obj_path), mp_renderer(p_renderer)
+Mesh::Mesh(const int ID, const std::string& obj_path, std::shared_ptr<Renderer> p_renderer) : m_ID(ID), m_obj_path(obj_path), mp_renderer(p_renderer)
 {
 	m_buffer.fill({ VK_NULL_HANDLE });
 	m_old_buffer.fill({ VK_NULL_HANDLE });

--- a/Engine/world/Mesh.h
+++ b/Engine/world/Mesh.h
@@ -21,33 +21,34 @@ public:
 	Mesh(const std::string& obj_path, std::shared_ptr<Renderer> p_renderer);
 	~Mesh();
 
-	void draw(const VkCommandBuffer& command_buffer);
+	void draw(const VkCommandBuffer& command_buffer, const int32_t frame);
 	void loadModel();
 	void bindMaterial(std::shared_ptr<Material> mat, VkBuffer& ubo, std::shared_ptr<Renderer> renderer);
 	void Delete();
 
 	void CreateBuffers(std::shared_ptr<Renderer> engine);
 	void DestroyOldBuffers();
-	void DestroyBuffers();
+	void DestroyBuffers(const int32_t frame);
 
 	void SetVertices(const std::vector<Vertex>& vertices);
 	void SetIndices(const std::vector<uint32_t>& indices);
 
 	std::vector<Vertex>& get_vertices();
 	std::vector<uint32_t>& get_indices();
-	Buffer& getBuffer();
-	Buffer* GetOldBuffer();
+	Buffer& GetBuffer(const int32_t frame);
+	Buffer* GetOldBuffer(const int32_t frame);
 	std::shared_ptr<Material> getMaterial();
 	const bool IsDestroyed();
+	const bool IsCleaned();
 
 private:
-	const std::string m_obj_path;
+	std::string m_obj_path;
 
 	std::vector<Vertex> m_vertices;
 	std::vector<uint32_t> m_indices;
 
-	Buffer* m_buffer;
-	Buffer* m_old_buffer;
+	std::array<Buffer*, MAX_FRAMES_IN_FLIGHT> m_buffer;
+	std::array<Buffer*, MAX_FRAMES_IN_FLIGHT> m_old_buffer;
 
 	std::shared_ptr<Material> p_material;
 	std::shared_ptr<Renderer> mp_renderer;

--- a/Engine/world/Mesh.h
+++ b/Engine/world/Mesh.h
@@ -17,17 +17,16 @@
 class Mesh
 {
 public:
-	Mesh(const int ID, std::vector<Vertex> vertices, std::vector<uint32_t> indices, std::shared_ptr<Renderer> p_renderer);
-	Mesh(const int ID, const std::string& obj_path, std::shared_ptr<Renderer> p_renderer);
+	Mesh(std::vector<Vertex> vertices, std::vector<uint32_t> indices, std::shared_ptr<Renderer> p_renderer);
+	Mesh(const std::string& obj_path, std::shared_ptr<Renderer> p_renderer);
 	~Mesh();//two destructors | one for move contrutor and one for classic destruction
 
 	void draw(const VkCommandBuffer& command_buffer, const int32_t frame);
 	void loadModel();
 	void bindMaterial(std::shared_ptr<Material> mat, VkBuffer& ubo, std::shared_ptr<Renderer> renderer);
-	void Delete();
 
 	void CreateBuffers(std::shared_ptr<Renderer> engine);
-	void DestroyOldBuffers();
+	void UpdateBuffers(const int32_t frame);
 	void DestroyBuffers(const int32_t frame);
 
 	void SetVertices(const std::vector<Vertex>& vertices);
@@ -36,25 +35,22 @@ public:
 	std::vector<Vertex>& get_vertices();
 	std::vector<uint32_t>& get_indices();
 	Buffer& GetBuffer(const int32_t frame);
-	Buffer& GetOldBuffer(const int32_t frame);
 	std::shared_ptr<Material> getMaterial();
-	const bool IsDestroyed();
 	const bool IsCleaned();
+	const bool IsUpdated();
 
 private:
-	int m_ID;
 	std::string m_obj_path;
 
 	std::vector<Vertex> m_vertices;
 	std::vector<uint32_t> m_indices;
 
 	std::array<Buffer, MAX_FRAMES_IN_FLIGHT> m_buffer;
-	std::array<Buffer, MAX_FRAMES_IN_FLIGHT> m_old_buffer;
 
 	std::shared_ptr<Material> p_material;
 	std::shared_ptr<Renderer> mp_renderer;
 
-	bool m_destroyed;
+	std::bitset<MAX_FRAMES_IN_FLIGHT> m_to_update;
 };
 
 #endif//!_MODEL_H

--- a/Engine/world/Mesh.h
+++ b/Engine/world/Mesh.h
@@ -17,9 +17,9 @@
 class Mesh
 {
 public:
-	Mesh(std::vector<Vertex> vertices, const std::vector<uint32_t>& indices, std::shared_ptr<Renderer> p_renderer);
-	Mesh(const std::string& obj_path, std::shared_ptr<Renderer> p_renderer);
-	~Mesh();
+	Mesh(const int ID, std::vector<Vertex> vertices, std::vector<uint32_t> indices, std::shared_ptr<Renderer> p_renderer);
+	Mesh(const int ID, const std::string& obj_path, std::shared_ptr<Renderer> p_renderer);
+	~Mesh();//two destructors | one for move contrutor and one for classic destruction
 
 	void draw(const VkCommandBuffer& command_buffer, const int32_t frame);
 	void loadModel();
@@ -42,6 +42,7 @@ public:
 	const bool IsCleaned();
 
 private:
+	int m_ID;
 	std::string m_obj_path;
 
 	std::vector<Vertex> m_vertices;

--- a/Engine/world/Mesh.h
+++ b/Engine/world/Mesh.h
@@ -36,7 +36,7 @@ public:
 	std::vector<Vertex>& get_vertices();
 	std::vector<uint32_t>& get_indices();
 	Buffer& GetBuffer(const int32_t frame);
-	Buffer* GetOldBuffer(const int32_t frame);
+	Buffer& GetOldBuffer(const int32_t frame);
 	std::shared_ptr<Material> getMaterial();
 	const bool IsDestroyed();
 	const bool IsCleaned();
@@ -47,8 +47,8 @@ private:
 	std::vector<Vertex> m_vertices;
 	std::vector<uint32_t> m_indices;
 
-	std::array<Buffer*, MAX_FRAMES_IN_FLIGHT> m_buffer;
-	std::array<Buffer*, MAX_FRAMES_IN_FLIGHT> m_old_buffer;
+	std::array<Buffer, MAX_FRAMES_IN_FLIGHT> m_buffer;
+	std::array<Buffer, MAX_FRAMES_IN_FLIGHT> m_old_buffer;
 
 	std::shared_ptr<Material> p_material;
 	std::shared_ptr<Renderer> mp_renderer;

--- a/Engine/world/Scene.cpp
+++ b/Engine/world/Scene.cpp
@@ -11,11 +11,13 @@ Scene::~Scene()
 	for (size_t i = 0; i < vp_objects.size(); i++)
 	{
 		vp_objects.erase(vp_objects.begin() + i);
+		--i;
 	}
 
 	for (size_t i = 0; i < vp_delete_queue.size(); i++)
 	{
 		vp_delete_queue.erase(vp_objects.begin() + i);
+		--i;
 	}
 }
 
@@ -72,7 +74,8 @@ void Scene::Clean(const int32_t frame)
 		vp_delete_queue[i]->Destroy(frame);
 		if (vp_delete_queue[i]->Deleted())
 		{
-			vp_objects.erase(vp_delete_queue.begin() + i);
+			vp_delete_queue.erase(vp_delete_queue.begin() + i);
+			--i;
 		}
 	}
 }
@@ -100,9 +103,17 @@ void Scene::UpdateUBO(std::shared_ptr<Camera> p_camera, std::shared_ptr<Renderer
 	}
 }
 
-void Scene::Update()
+void Scene::ToUpdate()
 {
 	m_changed.set();
+}
+
+void Scene::Update(const int32_t frame)
+{
+	for (size_t i = 0; i < vp_objects.size(); i++)
+	{
+		vp_objects[i]->Update(frame);
+	}
 }
 
 const bool& Scene::isUpdate(const int i)

--- a/Engine/world/Scene.cpp
+++ b/Engine/world/Scene.cpp
@@ -8,6 +8,15 @@ Scene::Scene()
 
 Scene::~Scene()
 {
+	for (size_t i = 0; i < vp_objects.size(); i++)
+	{
+		vp_objects.erase(vp_objects.begin() + i);
+	}
+
+	for (size_t i = 0; i < vp_delete_queue.size(); i++)
+	{
+		vp_delete_queue.erase(vp_objects.begin() + i);
+	}
 }
 
 R3DResult Scene::addGameObject(std::shared_ptr<GameObject> gameobject)
@@ -34,8 +43,7 @@ R3DResult Scene::removeGameObject(std::shared_ptr<GameObject> gameobject)
 	{
 		if (vp_objects[i] == gameobject)
 		{
-			vp_delete_queue.push_back(vp_objects[i]);
-
+			vp_delete_queue.push_back(std::move(vp_objects[i]));
 			vp_objects.erase(vp_objects.begin() + i);
 
 			m_changed.set();
@@ -47,43 +55,33 @@ R3DResult Scene::removeGameObject(std::shared_ptr<GameObject> gameobject)
 	return R3DResult::R3D_OBJECT_NOT_FOUND;
 }
 
-void Scene::render(VkCommandBuffer& command_buffer, const int i)
+void Scene::Render(VkCommandBuffer& command_buffer, const int32_t frame)
 {
 	for (size_t i = 0; i < vp_objects.size(); i++)
 	{
-		vp_objects[i]->registerDrawCmd(command_buffer);
+		vp_objects[i]->registerDrawCmd(command_buffer, frame);
 	}
 
-	m_changed.set(i, false);
+	m_changed.set(frame, false);
 }
 
-void Scene::Clean()
+void Scene::Clean(const int32_t frame)
 {
-	for (size_t i = 0; i < vp_objects.size(); i++)
+	for (size_t i = 0; i < vp_delete_queue.size(); i++)
 	{
-		vp_objects[i]->Clean();
-	}
-
-	if (m_changed == false)
-	{
-		for (size_t i = 0; i < vp_delete_queue.size(); i++)
+		vp_delete_queue[i]->Destroy(frame);
+		if (vp_delete_queue[i]->Deleted())
 		{
-			for (size_t t = 0; t < vp_delete_queue[i]->getMeshesCount(); t++)
-			{
-				vp_delete_queue[i]->getMesh(t).DestroyBuffers();
-			}
-
-			vp_delete_queue[i]->Clean();
-			vp_delete_queue.erase(vp_delete_queue.begin() + i);
+			vp_objects.erase(vp_delete_queue.begin() + i);
 		}
 	}
 }
 
-void Scene::UpdateUBO(std::shared_ptr<Camera> p_camera, std::shared_ptr<Renderer> p_renderer)
+void Scene::UpdateUBO(std::shared_ptr<Camera> p_camera, std::shared_ptr<Renderer> p_renderer, const int32_t frame)
 {
 	for (size_t i = 0; i < vp_objects.size(); i++)
 	{
-		UniformBufferObject ubo = p_camera->getUBO();
+		UniformBufferObject ubo = p_camera->GetUBO(frame);
 
 		glm::mat4 matrix = glm::mat4(1.0f);
 
@@ -96,9 +94,9 @@ void Scene::UpdateUBO(std::shared_ptr<Camera> p_camera, std::shared_ptr<Renderer
 		ubo.model = matrix;
 
 		void* data;
-		vkMapMemory(p_renderer->getDevice(), vp_objects[i]->getUBOMemory(), 0, sizeof(ubo), 0, &data);
-		memcpy(data, &ubo, sizeof(p_camera->getUBO()));
-		vkUnmapMemory(p_renderer->getDevice(), vp_objects[i]->getUBOMemory());
+		vkMapMemory(p_renderer->getDevice(), vp_objects[i]->GetUBOMemory(frame), 0, sizeof(ubo), 0, &data);
+		memcpy(data, &ubo, sizeof(p_camera->GetUBO(frame)));
+		vkUnmapMemory(p_renderer->getDevice(), vp_objects[i]->GetUBOMemory(frame));
 	}
 }
 

--- a/Engine/world/Scene.h
+++ b/Engine/world/Scene.h
@@ -19,10 +19,10 @@ public:
 	R3DResult addGameObject(std::shared_ptr<GameObject> gameobject);
 	R3DResult removeGameObject(std::shared_ptr<GameObject> gameobject);
 
-	void render(VkCommandBuffer& command_buffer, const int i);
-	void Clean();
+	void Render(VkCommandBuffer& command_buffer, const int32_t frame);
+	void Clean(const int32_t frame);
 
-	void UpdateUBO(std::shared_ptr<Camera> p_camera, std::shared_ptr<Renderer> p_renderer);
+	void UpdateUBO(std::shared_ptr<Camera> p_camera, std::shared_ptr<Renderer> p_renderer, const int32_t frame);
 
 	void Update();
 	const bool& isUpdate(const int i);

--- a/Engine/world/Scene.h
+++ b/Engine/world/Scene.h
@@ -24,7 +24,8 @@ public:
 
 	void UpdateUBO(std::shared_ptr<Camera> p_camera, std::shared_ptr<Renderer> p_renderer, const int32_t frame);
 
-	void Update();
+	void ToUpdate();
+	void Update(const int32_t frame);
 	const bool& isUpdate(const int i);
 	const bool IsUpdated();
 	std::vector<std::shared_ptr<GameObject>>& getObjects();

--- a/ExampleCube/main.cpp
+++ b/ExampleCube/main.cpp
@@ -87,33 +87,35 @@ int main()
 
 			if (init++ == 10000)
 			{
-				std::clog << "new cube" << std::endl;
+				std::clog << "Add New Mesh" << std::endl;
 				cube->LoadMesh(voxel.vertices, voxel.indices);
 				cube->bindMatToMesh(1, cube_texture);
-				scene->Update();
+				scene->ToUpdate();
 			}
 
-			/*if (init++ == 15000)
+			if (init == 15000)
 			{
 				Geometry v;
 				v.vertices = cube->GetVertices(1);
 				v.indices = cube->GetIndices(1);
 				v.vertices[0].color = { .0f, .0f, 1.0f };
 
+				std::clog << "Update Mesh" << std::endl;
 				cube->UpdateMesh(1, v.vertices, v.indices);
-				scene->Update();
+				scene->ToUpdate();
 			}
 
 			if (init == 20000)
 			{
+				std::clog << "Remove Gameobject" << std::endl;
 				scene->removeGameObject(cube);
-			}*/
+			}
 
 			engine.update();
 			engine.draw();
 		} while (!engine.shouldClose());
 	}
-	catch (const std::runtime_error& e)
+	catch (const std::exception& e)
 	{
 		std::cerr << e.what() << std::endl;
 		system("pause");//no system pause | try catch should be done more localy depending on where to end 

--- a/ExampleCube/main.cpp
+++ b/ExampleCube/main.cpp
@@ -85,7 +85,7 @@ int main()
 		{
 			//cube->setPosition(cube->getPosition() + glm::vec3{0.0001f, 0.f, 0.f});
 
-			if (init == 10000)
+			/*if (init == 10000)
 			{
 				cube->LoadMesh(voxel.vertices, voxel.indices);
 				cube->bindMatToMesh(1, cube_texture);
@@ -106,7 +106,7 @@ int main()
 			if (init == 20000)
 			{
 				scene->removeGameObject(cube);
-			}
+			}*/
 
 			engine.update();
 			engine.draw();

--- a/ExampleCube/main.cpp
+++ b/ExampleCube/main.cpp
@@ -85,14 +85,15 @@ int main()
 		{
 			//cube->setPosition(cube->getPosition() + glm::vec3{0.0001f, 0.f, 0.f});
 
-			/*if (init == 10000)
+			if (init++ == 10000)
 			{
+				std::clog << "new cube" << std::endl;
 				cube->LoadMesh(voxel.vertices, voxel.indices);
 				cube->bindMatToMesh(1, cube_texture);
 				scene->Update();
 			}
 
-			if (init++ == 15000)
+			/*if (init++ == 15000)
 			{
 				Geometry v;
 				v.vertices = cube->GetVertices(1);


### PR DESCRIPTION
- Fix cleaning object
- *To Fix* Gameobject buffer lifesapn should begin when adding to scene and end when removing from the scene
- Multi-buffering for vertex, index and ubo buffers. Number of buffers is defined by Swapchain image number